### PR TITLE
Remove noise that might wrap filenames

### DIFF
--- a/UniExtract.au3
+++ b/UniExtract.au3
@@ -500,6 +500,8 @@ EndFunc
 Func FilenameParse($f)
 	If StringIsSpace($f) Then Return SetError(1)
 
+	; Trim noise and unwrap. 
+	$f = StringRegExpReplace($f,'^[ "]*|([^\\])[ "]*$','\1')
 	$file = _PathFull($f)
 	$filedir = StringLeft($f, StringInStr($f, "\", 0, -1) - 1)
 	$filename = StringTrimLeft($f, StringInStr($f, "\", 0, -1))


### PR DESCRIPTION
If I use `CTRL`+`SHIFT`+`c` (a.k.a. "copy as path") in Windows, the OS wraps the string with `"` and UniExtract borks.
Added trimming of ` ` (spaces) was suggested in https://www.autoitscript.com/forum/topic/129430-remove-quotations-csv/